### PR TITLE
added expires_date_attrs

### DIFF
--- a/lib/itunes_receipt_mock/mixins.rb
+++ b/lib/itunes_receipt_mock/mixins.rb
@@ -20,5 +20,15 @@ module ItunesReceiptMock
           .strftime('%F %T') + ' America/Los_Angeles'
       }
     end
+
+    def expires_date_attrs(date)
+      {
+        'expires_date' => date.to_time.utc.strftime('%s%L'),
+        'expires_date_formatted' => date.to_time.utc
+          .strftime('%F %T') + ' Etc/GMT',
+        'expires_date_formatted_pst' => date.to_time.getlocal('-08:00')
+          .strftime('%F %T') + ' America/Los_Angeles'
+      }
+    end
   end
 end

--- a/lib/itunes_receipt_mock/subscription.rb
+++ b/lib/itunes_receipt_mock/subscription.rb
@@ -35,7 +35,7 @@ module ItunesReceiptMock
     def as_json
       super.merge(
         'web_order_line_item_id' => web_order_line_item_id.to_s
-      ).merge(date_attrs('expires', expires_date))
+      ).merge(expires_date_attrs(expires_date))
     end
   end
 end

--- a/spec/itunes_receipt_mock_spec.rb
+++ b/spec/itunes_receipt_mock_spec.rb
@@ -301,6 +301,24 @@ describe ItunesReceiptMock do
       end
     end
 
+    shared_examples 'expires a date' do
+      it 'displays the date as a ms timestamp' do
+        expect(json['expires_date'])
+          .to eq(date.utc.strftime('%s%L'))
+      end
+
+      it 'displays the date as a ms timestamp' do
+        expect(json['expires_date_formatted'])
+          .to eq(date.utc.strftime('%F %T') + ' Etc/GMT')
+      end
+
+      it 'displays the date in PST' do
+        expect(json['expires_date_formatted_pst'])
+          .to eq(date.getlocal('-08:00').strftime('%F %T') +
+                 ' America/Los_Angeles')
+      end
+    end
+
     shared_examples 'a purchase json object' do
       it 'contains all the details for a purchase' do
         expect(json['product_id']).to eq(obj.product_id)
@@ -333,8 +351,7 @@ describe ItunesReceiptMock do
 
       describe 'expires date' do
         let(:date) { obj.expires_date }
-        let(:prefix) { 'expires' }
-        it_behaves_like 'a date'
+        it_behaves_like 'expires a date'
       end
     end
 


### PR DESCRIPTION
This Gem receipt:

``` json
"expires_date": "2016-01-16 05:51:35 Etc/GMT",
"expires_date_ms": "1452923495000",
"expires_date_pst": "2016-01-15 21:51:35 America/Los_Angeles",
```

But, real receipt:

``` json
"expires_date_formatted": "2016-01-16 05:51:35 Etc/GMT",
"expires_date": "1452923495000",
"expires_date_formatted_pst": "2016-01-15 21:51:35 America/Los_Angeles",
```

So, I added `expires_date_attrs`.
